### PR TITLE
Fix overflow of reported size above ~2GB

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -44,7 +44,8 @@ void print_size(long size, char human) {
 
 int main(int argc, char **argv) {
 
-        int fd, fsize;
+        int fd;
+        long long fsize;
         unsigned long long size;
 
         int optch;

--- a/src/gzsize.c
+++ b/src/gzsize.c
@@ -6,7 +6,7 @@
 #include "gzsize.h"
 
 
-long get_size(int fd) {
+long long get_size(int fd) {
         int ret;
         z_stream strm;
         unsigned char in[CHUNK];

--- a/src/gzsize.h
+++ b/src/gzsize.h
@@ -8,6 +8,6 @@ enum {
 /**
  * Decompress an input stream on /dev/null and compute its decompressed size.
  **/
-long get_size(int fd);
+long long get_size(int fd);
 
 #endif


### PR DESCRIPTION
The return type of `get_size` was only guaranteed to be 32 bits (and not signed) which overflows at around 2GB. By replacing it with a `long long` which is guaranteed to be 64 bits, we fix the overflow.

Fixes #1.

I've tested this manually:
```
head -c 5G </dev/urandom > random_bytes
gzip -c random_bytes > random_bytes.gz

# With this fix
gzsize random_bytes.gz
5368709120

# Without this fix
gzsize random_bytes.gz
1073741824

# To check
gzip -dc random_bytes.gz | wc -c                  
5368709120
```